### PR TITLE
fix incident email subject, the comma.. why

### DIFF
--- a/whalebrary/emails.py
+++ b/whalebrary/emails.py
@@ -9,8 +9,9 @@ class NewIncidentEmail(Email):
                     ]
 
     def get_subject(self):
+
         return '{} - {} - {}'.format(self.instance.get_incident_type_display(), self.instance.species,
-                          self.instance.first_report.strftime("%B %d, %Y @ %I:%M %p %Z")),
+                          self.instance.first_report.strftime("%B %d, %Y @ %I:%M %p %Z"))
 
 
 


### PR DESCRIPTION
fixed subject line for email so should be string now