### PR TITLE
Reqs and small settings.py change for Python 3.9 and GeOsPaTiAl FUN!

### DIFF
--- a/dm_apps/settings.py
+++ b/dm_apps/settings.py
@@ -307,6 +307,7 @@ TRACK_SUPERUSERS = False
 
 if "win" in sys.platform.lower() and GEODJANGO:
     GDAL_LIBRARY_PATH = config("GDAL_LIBRARY_PATH", cast=str, default="")
+    GEOS_LIBRARY_PATH = config("GEOS_LIBRARY_PATH", cast=str, default="")
 
 if USE_AZURE_APPLICATION_INSIGHT and AZURE_INSTRUMENTATION_KEY != "":
     LOGGING = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ cffi==1.14.3
 chardet==4.0.0
 cryptography==3.3.2
 cssselect2==0.4.1
-cx-Oracle==7.1.3
+cx-Oracle==8.1.0
 defusedxml==0.6.0
 Deprecated==1.2.10
 django-bootstrap4==2.3.1
@@ -46,8 +46,8 @@ Markdown==3.3.3
 MarkupSafe==1.1.1
 msrest==0.6.19
 msrestazure==0.6.4
-mysqlclient==1.4.6
-numpy==1.19.2
+mysqlclient==2.0.3
+numpy==1.19.4
 oauthlib==3.1.0
 opencensus-context==0.1.2
 opencensus-ext-azure==1.0.5
@@ -59,7 +59,7 @@ pandas==1.1.3
 phonenumberslite==8.12.8
 Pillow==8.3.2
 protobuf==3.13.0
-psutil==5.7.3
+psutil==5.8.0
 pyasn1-modules==0.2.8
 pyasn1==0.4.8
 pycparser==2.20
@@ -73,7 +73,7 @@ python-dateutil==2.8.1
 python-decouple==3.3
 python-docx==0.8.10
 python-http-client==3.3.1
-python-Levenshtein==0.12.0
+python-Levenshtein==0.12.2
 pytz==2020.1
 PyYAML==5.4
 regex==2020.10.28
@@ -83,7 +83,7 @@ requests==2.25.1
 rsa==4.7
 selenium==3.141.0
 sendgrid==6.4.7
-shapely==1.7.1
+shapely==1.8.0
 six==1.15.0
 soupsieve==2.0.1
 sqlparse==0.4.2


### PR DESCRIPTION
my notes and what worked for me finally:

cx-Oracle==8.1.0 #original 7.1.3
mysqlclient==2.0.3 #original 1.4.6, had error with caching_sha2_password
numpy==1.19.4 #original 1.19.2
psutil==5.8.0 #original 5.7.3
python-Levenshtein==0.12.2 #original 0.12.0 - had to download wheel from https://www.lfd.uci.edu/~gohlke/pythonlibs/#python-levenshtein
shapely==1.8.0 #original 1.7.1, had error: OSError: Could not find lib geos_c.dll or load any of its variants [].