### PR TITLE
Dependency bump

### DIFF
--- a/ihub/reports.py
+++ b/ihub/reports.py
@@ -15,9 +15,19 @@ from . import models
 from .utils import get_date_range_overlap
 
 
+def get_target_dir():
+    dir = os.path.join(settings.BASE_DIR, 'media', 'ihub', 'temp')
+    
+    if not os.path.exists(dir):
+        print(f"{dir} does not exist. Creating...")
+        os.makedirs(dir)
+    
+    return dir
+
+
 def generate_capacity_spreadsheet(orgs, sectors, from_date, to_date):
     # figure out the filename
-    target_dir = os.path.join(settings.BASE_DIR, 'media', 'ihub', 'temp')
+    target_dir = get_target_dir()
     target_file = "temp_data_export_{}.xlsx".format(timezone.now().strftime("%Y-%m-%d"))
     target_file_path = os.path.join(target_dir, target_file)
     target_url = os.path.join(settings.MEDIA_ROOT, 'ihub', 'temp', target_file)
@@ -215,7 +225,7 @@ def generate_capacity_spreadsheet(orgs, sectors, from_date, to_date):
 
 def generate_summary_spreadsheet(orgs, sectors, from_date, to_date, entry_note_types, entry_note_statuses):
     # figure out the filename
-    target_dir = os.path.join(settings.BASE_DIR, 'media', 'ihub', 'temp')
+    target_dir = get_target_dir()
     target_file = "temp_data_export_{}.xlsx".format(timezone.now().strftime("%Y-%m-%d"))
     target_file_path = os.path.join(target_dir, target_file)
     target_url = os.path.join(settings.MEDIA_ROOT, 'ihub', 'temp', target_file)
@@ -461,7 +471,7 @@ def generate_summary_spreadsheet(orgs, sectors, from_date, to_date, entry_note_t
 def generate_consultation_log_spreadsheet(orgs, sectors, statuses, entry_types, report_title, from_date, to_date, entry_note_types,
                                           entry_note_statuses):
     # figure out the filename
-    target_dir = os.path.join(settings.BASE_DIR, 'media', 'ihub', 'temp')
+    target_dir = get_target_dir()
     target_file = "temp_data_export_{}.xlsx".format(timezone.now().strftime("%Y-%m-%d"))
     target_file_path = os.path.join(target_dir, target_file)
     target_url = os.path.join(settings.MEDIA_ROOT, 'ihub', 'temp', target_file)
@@ -613,7 +623,7 @@ def generate_consultation_log_spreadsheet(orgs, sectors, statuses, entry_types, 
 
 def consultation_instructions_export_spreadsheet(orgs=None):
     # figure out the filename
-    target_dir = os.path.join(settings.BASE_DIR, 'media', 'ihub', 'temp')
+    target_dir = get_target_dir()
     target_file = "temp_data_export_{}.xlsx".format(timezone.now().strftime("%Y-%m-%d"))
     target_file_path = os.path.join(target_dir, target_file)
     target_url = os.path.join(settings.MEDIA_ROOT, 'ihub', 'temp', target_file)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ arabic-reshaper==2.1.0
 asgiref==3.3.4
 azure-common==1.1.25
 beautifulsoup4==4.9.3
-bokeh==2.2.3
+bokeh==2.4.3
 boto3==1.17.18
 cachetools==4.1.1
 cairocffi==1.1.0
@@ -13,7 +13,7 @@ celery==5.2.3
 certifi==2020.6.20
 cffi==1.15.0
 chardet==4.0.0
-cryptography==3.3.2
+cryptography==37.0.1
 cssselect2==0.4.1
 cx-Oracle==8.1.0
 defusedxml==0.6.0
@@ -85,12 +85,12 @@ pytz==2021.3
 PyYAML==5.4
 redis==4.1.1
 regex==2020.10.28
-reportlab==3.5.55
+reportlab==3.6.10
 requests-oauthlib==1.3.0
 requests==2.25.1
 rsa==4.7
 selenium==3.141.0
-sendgrid==6.4.7
+sendgrid==6.9.7
 shapely==1.8.0
 six==1.15.0
 soupsieve==2.0.1
@@ -100,7 +100,7 @@ text-unidecode==1.3
 textile==4.0.1
 tinycss2==1.0.2
 tornado==6.0.4
-typing-extensions==3.7.4.3
+typing-extensions==4.3.0
 tzdata==2022.1 ##added for timezone testing/import
 unicodecsv==0.14.1
 Unidecode==1.2.0
@@ -109,6 +109,6 @@ WeasyPrint==51
 webencodings==0.5.1
 whitenoise==5.2.0
 wrapt==1.12.1
-xhtml2pdf==0.2.5
+xhtml2pdf==0.2.8
 xlrd==2.0.1
 XlsxWriter==1.3.7


### PR DESCRIPTION
# Dependency Bump

Addresses CVEs in:
- Sendgrid
- boken
- reportlab

Cryptography updated to allow use of OpenSSL 3, please see [changelog](https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst) from 3.3.2 and up.

DM-Apps installation tested on M1 Pro for development.

# iHub

Helper: When a report is generated, check that the media folder exists and create it otherwise.