### PR TITLE
Removed \" from french translation to avoid breaking string in JavaSc…

### DIFF
--- a/csas2/locale/fr/LC_MESSAGES/django.po
+++ b/csas2/locale/fr/LC_MESSAGES/django.po
@@ -3485,7 +3485,7 @@ msgid ""
 "WARNING: This reviewer's status is 'pending'. If you choose to continue, "
 "they will receive a notification message to inform them about this change."
 msgstr ""
-"AVERTISSEMENT : Le statut de cet examinateur est \"en attente\". Si vous "
+"AVERTISSEMENT : Le statut de cet examinateur est 'en attente'. Si vous "
 "choisissez de continuer, il recevra un message de notification pour "
 "l'informer de ce changement."
 


### PR DESCRIPTION
Using the double-quoted word in the french locale key caused JavaScript code to break and DM-Apps to fail to load the request_detail and tor views when DM-Apps is set to the french locale. This hotfix removes them in favour of single-quote for now.

Because {% trans %} removes the escape character of translation strings, it may be better to either use the Django [JavascriptCatalogue](https://docs.djangoproject.com/en/4.1/topics/i18n/translation/#internationalization-in-javascript-code) or the use of [character codes](https://www.rapidtables.com/web/html/html-codes.html) if Django does not change them to ASCII with the translation function. 

We should check if other translation keys are also affected.