### PR TITLE
initialize committee field correctly on person update view

### DIFF
--- a/maret/views.py
+++ b/maret/views.py
@@ -237,6 +237,16 @@ class PersonUpdateView(AuthorRequiredMixin, CommonUpdateViewHelp):
     template_name = "maret/form.html"
     h1 = gettext_lazy("Contact")
 
+    def get_initial(self):
+        committees = []
+        if models.Committee.objects.filter(external_contact__in=[self.object]):
+            committees_qs = models.Committee.objects.filter(external_contact__in=[self.object])
+            committees = [c.pk for c in committees_qs]
+
+        return {
+            'committee': committees,
+        }
+
     def form_valid(self, form):
         obj = form.save(commit=False)
         if obj.locked_by_ihub:


### PR DESCRIPTION
Small PR for fixing single bug.  
Committee field was not getting populated on update views, added this to the get initial method.  