### PR TITLE
add disclaimer text to status reports

### DIFF
--- a/ppt/templates/ppt/project_detail/components/status_report_modal.html
+++ b/ppt/templates/ppt/project_detail/components/status_report_modal.html
@@ -3,6 +3,7 @@
 {% load custom_filters %}
 {% load project_filters %}
 {% load static %}
+
 <!-- template for the modal component -->
 <script type="text/x-template" id="status-report-modal-template">
 <transition name="modal">
@@ -30,13 +31,17 @@
               {% for field in status_report_form %}
                 {% if field.name|is_markdown_field %}
 
-                  <label for="id_priorities">{{ field.label }}</label>
+                  <label>{{ field.label }}</label>
                   <a href="{% static 'markdown-cheatsheet-online.pdf' %}" data-toggle="tooltip" target="_blank" tabindex="-1"
                      title="{% trans "Markdown syntax is supported in this field" %}">
                     <span class="mdi mdi-language-markdown ml-1 py-0" style="font-size: 20px; color: blue"></span>
                   </a>
                   {% bootstrap_field field placeholder="" show_label=False size='small' %}
 
+                {% elif 'insuficient_funds_amt' in field.name %}
+                  {% bootstrap_label field.label label_for="id_"|add:field.name %}
+                  <span class="mdi mdi-help-circle-outline h6"  title=" {% trans "Requested funds not guarenteed" %}"></span>
+                  {% bootstrap_field field placeholder="" show_label=False size='small' %}
                 {% else %}
                   {% bootstrap_field field placeholder="" size='small' %}
                 {% endif %}


### PR DESCRIPTION
Hot fix's in a help text to tell users that requesting funds is not the same as getting them in status reports.